### PR TITLE
Fixed event shorthand depracation issues

### DIFF
--- a/99robots-custom-image-sizes.php
+++ b/99robots-custom-image-sizes.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:	Custom Image Sizes by DraftPress
- * Plugin URI:	https://draftpress.com/custom-image-sizes/
+ * Plugin URI:	https://wordpress.org/plugins/custom-image-sizes-by-draftpress/
  * Description:	Custom Image Sizes by DraftPress is a quick and simple way for you to add your own image sizes to your WordPress site.
  * Version: 1.2.7
  * Author: DraftPress

--- a/99robots-custom-image-sizes.php
+++ b/99robots-custom-image-sizes.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * Plugin Name:	Custom Image Sizes by 99 Robots
- * Plugin URI:	https://draftpress.com/products/?utm_source=plugin-uri&utm_medium=custom-image-sizes&utm_campaign=plugins-page
+ * Plugin URI:	https://draftpress.com/custom-image-sizes/
  * Description:	Custom Image Sizes by 99 Robots is a quick and simple way for you to add your own image sizes to your WordPress site.
- * Version: 1.2.6
- * Author: 99 Robots
- * Author URI: https://draftpress.com
+ * Version: 1.2.7
+ * Author: DraftPress
+ * Author URI: https://draftpress.com/
  * License: GPL2
  * License URI:	http://www.gnu.org/licenses/gpl-2.0.txt
- * Text Domain:	99robots-custom-image-sizes
+ * Text Domain:	draftpress-custom-image-sizes
  * Domain Path: /languages
  */
 
@@ -26,7 +26,7 @@ class NNR_Custom_Image_Sizes {
 	 * NNR_Custom_Image_Sizes version.
 	 * @var string
 	 */
-	public $version = '1.2.6';
+	public $version = '1.2.7';
 
 	/**
 	 * The single instance of the class.

--- a/99robots-custom-image-sizes.php
+++ b/99robots-custom-image-sizes.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Plugin Name:	Custom Image Sizes by 99 Robots
+ * Plugin Name:	Custom Image Sizes by DraftPress
  * Plugin URI:	https://draftpress.com/custom-image-sizes/
- * Description:	Custom Image Sizes by 99 Robots is a quick and simple way for you to add your own image sizes to your WordPress site.
+ * Description:	Custom Image Sizes by DraftPress is a quick and simple way for you to add your own image sizes to your WordPress site.
  * Version: 1.2.7
  * Author: DraftPress
  * Author URI: https://draftpress.com/
  * License: GPL2
  * License URI:	http://www.gnu.org/licenses/gpl-2.0.txt
- * Text Domain:	draftpress-custom-image-sizes
+ * Text Domain:	99robots-custom-image-sizes
  * Domain Path: /languages
  */
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,8 +1,8 @@
-jQuery(document).ready(function($){
+jQuery(function($){
 
 	// Add a new one
 
-	$('.' + nnr_cis_settings_data.prefix + 'repeater-add-new').click(function(){
+	$('.' + nnr_cis_settings_data.prefix + 'repeater-add-new').on("click", function(){
 
 		var new_row = '<tr class="' + nnr_cis_settings_data.prefix + 'repeater-item">' +
 			'<td class="' + nnr_cis_settings_data.prefix + 'repeater-item-name"><input type="text" class="form-control input-sm" name="' + nnr_cis_settings_data.prefix + 'name[]" value="New Image Size"/></td>' +
@@ -30,13 +30,13 @@ jQuery(document).ready(function($){
 
 	// Remove one
 
-	$(document).on('click', '.' + nnr_cis_settings_data.prefix + 'repeater-remove', function(){
+	$('.' + nnr_cis_settings_data.prefix + 'repeater-remove').on('click', function(){
 
 		$('#' + nnr_cis_settings_data.prefix + 'delete-image-size-modal').modal();
 
 		var delete_image_size = $(this);
 
-		$('.' + nnr_cis_settings_data.prefix + 'delete-image-size').click(function(){
+		$('.' + nnr_cis_settings_data.prefix + 'delete-image-size').on("click", function(){
 			delete_image_size.parent().parent().remove();
 		});
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Custom Image Sizes by 99 Robots ===
-Contributors: 99robots, charliepatel, draftpress
+Contributors: 99robots, charliepatel, DraftPress
 Donate link:
 Tags: image sizes, images, image, size, sizes, custom sizes, custom image, custom images
 Requires at least: 4.5
-Tested up to: 5.6
-Stable tag: 1.2.6
+Tested up to: 5.7.2
+Stable tag: 1.2.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,10 @@ Also please check out our other [plugins](https://draftpress.com/products/?utm_s
 2. Select your image size when inserting image into a post
 
 == Changelog ==
+
+= 1.2.7 = 2021-06-10
+* Updated to make compatible with WordPress 5.7.2
+* FIXED: Event shorthand depracation issues.
 
 = 1.2.6 = 2020-12-28
 * Updated to make compatible with WordPress 5.6

--- a/readme.txt
+++ b/readme.txt
@@ -31,7 +31,7 @@ Also please check out our other [plugins](https://draftpress.com/products/?utm_s
 
 = 1.2.7 = 2021-06-10
 * Updated to make compatible with WordPress 5.7.2
-* FIXED: Event shorthand depracation issues.
+* FIXED: Event shorthand deprecation issues.
 
 = 1.2.6 = 2020-12-28
 * Updated to make compatible with WordPress 5.6


### PR DESCRIPTION
### Made Compatible with WordPress 5.7.2

changed : `jQuery(document).ready(function($){`  
to:  `jQuery(function($){`

changed `.click(function(){`  
to: `.on('click', function() {`