### PR TITLE
Updated Text Domain to draftpress-custom-image-sizes

### DIFF
--- a/99robots-custom-image-sizes.php
+++ b/99robots-custom-image-sizes.php
@@ -3,12 +3,12 @@
  * Plugin Name:	Custom Image Sizes by DraftPress
  * Plugin URI:	https://wordpress.org/plugins/custom-image-sizes-by-draftpress/
  * Description:	Custom Image Sizes by DraftPress is a quick and simple way for you to add your own image sizes to your WordPress site.
- * Version: 1.2.7
+ * Version: 1.2.8
  * Author: DraftPress
  * Author URI: https://draftpress.com/
  * License: GPL2
  * License URI:	http://www.gnu.org/licenses/gpl-2.0.txt
- * Text Domain:	99robots-custom-image-sizes
+ * Text Domain:	draftpress-custom-image-sizes
  * Domain Path: /languages
  */
 
@@ -83,14 +83,14 @@ class NNR_Custom_Image_Sizes {
 	 * Cloning is forbidden.
 	 */
 	public function __clone() {
-		wc_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', '99robots-custom-image-sizes' ), $this->version );
+		wc_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'draftpress-custom-image-sizes' ), $this->version );
 	}
 
 	/**
 	 * Unserializing instances of this class is forbidden.
 	 */
 	public function __wakeup() {
-		wc_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', '99robots-custom-image-sizes' ), $this->version );
+		wc_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'draftpress-custom-image-sizes' ), $this->version );
 	}
 
 	/**
@@ -139,15 +139,15 @@ class NNR_Custom_Image_Sizes {
 	 */
 	public function load_plugin_textdomain() {
 
-		$locale = apply_filters( 'plugin_locale', get_locale(), '99robots-custom-image-sizes' );
+		$locale = apply_filters( 'plugin_locale', get_locale(), 'draftpress-custom-image-sizes' );
 
 		load_textdomain(
-			'99robots-custom-image-sizes',
+			'draftpress-custom-image-sizes',
 			WP_LANG_DIR . '/custom-image-sizes-by-99-robots/custom-image-sizes-by-99-robots-' . $locale . '.mo'
 		);
 
 		load_plugin_textdomain(
-			'99robots-custom-image-sizes',
+			'draftpress-custom-image-sizes',
 			false,
 			$this->plugin_dir() . '/languages/'
 		);
@@ -184,7 +184,7 @@ class NNR_Custom_Image_Sizes {
 	 */
 	public function plugin_links( $links ) {
 
-		$settings_link = '<a href="' . get_admin_url() . 'options-general.php?page=' . self::$settings_page . '">' . esc_html__( 'Settings', '99robots-custom-image-sizes' ) . '</a>';
+		$settings_link = '<a href="' . get_admin_url() . 'options-general.php?page=' . self::$settings_page . '">' . esc_html__( 'Settings', 'draftpress-custom-image-sizes' ) . '</a>';
 		array_unshift( $links, $settings_link );
 
 		return $links;
@@ -199,8 +199,8 @@ class NNR_Custom_Image_Sizes {
 
 		$settings_page_load = add_submenu_page(
 			'options-general.php',
-			esc_html__( 'Custom Image Sizes', '99robots-custom-image-sizes' ),
-			esc_html__( 'Custom Image Sizes', '99robots-custom-image-sizes' ),
+			esc_html__( 'Custom Image Sizes', 'draftpress-custom-image-sizes' ),
+			esc_html__( 'Custom Image Sizes', 'draftpress-custom-image-sizes' ),
 			'manage_options',
 			self::$settings_page,
 			array( $this, 'render_settings' )
@@ -275,7 +275,7 @@ class NNR_Custom_Image_Sizes {
 				$sizes[ $_size ]['width'] = get_option( $_size . '_size_w' );
 				$sizes[ $_size ]['height'] = get_option( $_size . '_size_h' );
 				$sizes[ $_size ]['crop'] = (bool) get_option( $_size . '_crop' );
-				$sizes[ $_size ]['source'] = esc_html__( 'WP Core', '99robots-custom-image-sizes' );
+				$sizes[ $_size ]['source'] = esc_html__( 'WP Core', 'draftpress-custom-image-sizes' );
 
 				$names[] = $_size;
 
@@ -285,7 +285,7 @@ class NNR_Custom_Image_Sizes {
 					'width' 	=> $_wp_additional_image_sizes[ $_size ]['width'],
 					'height' 	=> $_wp_additional_image_sizes[ $_size ]['height'],
 					'crop' 		=> $_wp_additional_image_sizes[ $_size ]['crop'],
-					'source'	=> esc_html__( 'Active Theme or Plugin', '99robots-custom-image-sizes' ),
+					'source'	=> esc_html__( 'Active Theme or Plugin', 'draftpress-custom-image-sizes' ),
 				);
 
 				$names[] = $_size;

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: 99robots, charliepatel, DraftPress
 Donate link:
 Tags: image sizes, images, image, size, sizes, custom sizes, custom image, custom images
 Requires at least: 4.5
-Tested up to: 5.7.2
-Stable tag: 1.2.7
+Tested up to: 5.8
+Stable tag: 1.2.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,7 +18,7 @@ Also please check out our other [plugins](https://draftpress.com/products/?utm_s
 
 == Installation ==
 
-1. Upload `99robots-custom-image-sizes` to the `/wp-content/plugins/` directory
+1. Upload `draftpress-custom-image-sizes` to the `/wp-content/plugins/` directory
 1. Activate the plugin through the 'Plugins' menu in WordPress
 1. Go to plugins page to see instructions for shortcode and php template tags
 
@@ -28,6 +28,9 @@ Also please check out our other [plugins](https://draftpress.com/products/?utm_s
 2. Select your image size when inserting image into a post
 
 == Changelog ==
+
+= 1.2.8 = 2021-08-16
+* Updated to make compatible with WordPress 5.8
 
 = 1.2.7 = 2021-06-23
 * Updated to make compatible with WordPress 5.7.2

--- a/views/header.php
+++ b/views/header.php
@@ -4,12 +4,12 @@
 	<div class="nnr-logo"></div>
 
 	<div class="nnr-product-details">
-		<span class="nnr-product-name"><?php esc_html_e( 'Custom Image Sizes', '99robots-custom-image-sizes' ) ?></span>
+		<span class="nnr-product-name"><?php esc_html_e( 'Custom Image Sizes', 'draftpress-custom-image-sizes' ) ?></span>
 		<span class="nnr-product-version"><?php echo wps_custom_sizes()->get_version() ?></span>
 	</div>
 
 	<a href="http://draftpress.com/products" target="_blank">
-		<button class="nnr-header-button pull-right"><?php esc_html_e( 'More Products', '99robots-custom-image-sizes' ) ?></button>
+		<button class="nnr-header-button pull-right"><?php esc_html_e( 'More Products', 'draftpress-custom-image-sizes' ) ?></button>
 	</a>
 
 </div>

--- a/views/settings.php
+++ b/views/settings.php
@@ -8,19 +8,19 @@
 
 			<form method="post">
 
-				<h1 id="nnr-heading"><?php esc_html_e( 'Settings', '99robots-custom-image-sizes' ) ?>
+				<h1 id="nnr-heading"><?php esc_html_e( 'Settings', 'draftpress-custom-image-sizes' ) ?>
 					<small>
-						<a class="nnr-heading-button-left btn btn-success <?php echo self::$prefix_dash ?>repeater-add-new"><i class="fa fa-plus fa-lg"></i> <?php esc_html_e( 'Add New', '99robots-custom-image-sizes' ) ?></a>
+						<a class="nnr-heading-button-left btn btn-success <?php echo self::$prefix_dash ?>repeater-add-new"><i class="fa fa-plus fa-lg"></i> <?php esc_html_e( 'Add New', 'draftpress-custom-image-sizes' ) ?></a>
 					</small>
 				</h1>
 
 				<table class="table table-responsive table-striped">
 					<thead>
-						<th><?php esc_html_e( 'Name', '99robots-custom-image-sizes' ) ?></th>
-						<th><?php esc_html_e( 'Width', '99robots-custom-image-sizes' ) ?></th>
-						<th><?php esc_html_e( 'Height', '99robots-custom-image-sizes' ) ?></th>
-						<th><?php esc_html_e( 'Crop', '99robots-custom-image-sizes' ) ?></th>
-						<th><?php esc_html_e( 'Source', '99robots-custom-image-sizes' ) ?></th>
+						<th><?php esc_html_e( 'Name', 'draftpress-custom-image-sizes' ) ?></th>
+						<th><?php esc_html_e( 'Width', 'draftpress-custom-image-sizes' ) ?></th>
+						<th><?php esc_html_e( 'Height', 'draftpress-custom-image-sizes' ) ?></th>
+						<th><?php esc_html_e( 'Crop', 'draftpress-custom-image-sizes' ) ?></th>
+						<th><?php esc_html_e( 'Source', 'draftpress-custom-image-sizes' ) ?></th>
 					</thead>
 
 					<tbody class="<?php echo self::$prefix_dash ?>repeater-container">
@@ -34,10 +34,10 @@
 								<td class="<?php echo self::$prefix_dash ?>repeater-item-crop">
 								<?php
 
-								$crop = esc_html__( 'No', '99robots-custom-image-sizes' );
+								$crop = esc_html__( 'No', 'draftpress-custom-image-sizes' );
 
 								if ( $size['crop'] ) {
-									$crop = esc_html__( 'Yes', '99robots-custom-image-sizes' );
+									$crop = esc_html__( 'Yes', 'draftpress-custom-image-sizes' );
 								} else if ( is_array( $size['crop'] ) ) {
 									$crop = implode( ' ', $size['crop'] );
 								}
@@ -64,17 +64,17 @@
 								</td>
 								<td class="<?php echo self::$prefix_dash ?>repeater-item-crop">
 									<select class="form-control input-sm" name="<?php echo self::$prefix_dash ?>crop[]">
-										<option value="false" <?php selected( 'false', $size['crop'], true ) ?>><?php esc_html_e( 'No', '99robots-custom-image-sizes' ) ?></option>
-										<option value="true" <?php selected( 'true', $size['crop'], true ) ?>><?php esc_html_e( 'Yes', '99robots-custom-image-sizes' ) ?></option>
-										<option value="left_top" <?php selected( 'left_top', $size['crop'], true ) ?>><?php esc_html_e( 'Left Top', '99robots-custom-image-sizes' ) ?></option>
-										<option value="center_top" <?php selected( 'center_top', $size['crop'], true ) ?>><?php esc_html_e( 'Center Top', '99robots-custom-image-sizes' ) ?></option>
-										<option value="right_top" <?php selected( 'right_top', $size['crop'], true ) ?>><?php esc_html_e( 'Right Top', '99robots-custom-image-sizes' ) ?></option>
-										<option value="left_center" <?php selected( 'left_center', $size['crop'], true ) ?>><?php esc_html_e( 'Left Center', '99robots-custom-image-sizes' ) ?></option>
-										<option value="center_center" <?php selected( 'center_center', $size['crop'], true ) ?>><?php esc_html_e( 'Center Center', '99robots-custom-image-sizes' ) ?></option>
-										<option value="right_center" <?php selected( 'right_center', $size['crop'], true ) ?>><?php esc_html_e( 'Right Center', '99robots-custom-image-sizes' ) ?></option>
-										<option value="left_bottom" <?php selected( 'left_bottom', $size['crop'], true ) ?>><?php esc_html_e( 'Left Bottom', '99robots-custom-image-sizes' ) ?></option>
-										<option value="center_bottom" <?php selected( 'center_bottom', $size['crop'], true ) ?>><?php esc_html_e( 'Center Bottom', '99robots-custom-image-sizes' ) ?></option>
-										<option value="right_bottom" <?php selected( 'right_bottom', $size['crop'], true ) ?>><?php esc_html_e( 'Right Bottom', '99robots-custom-image-sizes' ) ?></option>
+										<option value="false" <?php selected( 'false', $size['crop'], true ) ?>><?php esc_html_e( 'No', 'draftpress-custom-image-sizes' ) ?></option>
+										<option value="true" <?php selected( 'true', $size['crop'], true ) ?>><?php esc_html_e( 'Yes', 'draftpress-custom-image-sizes' ) ?></option>
+										<option value="left_top" <?php selected( 'left_top', $size['crop'], true ) ?>><?php esc_html_e( 'Left Top', 'draftpress-custom-image-sizes' ) ?></option>
+										<option value="center_top" <?php selected( 'center_top', $size['crop'], true ) ?>><?php esc_html_e( 'Center Top', 'draftpress-custom-image-sizes' ) ?></option>
+										<option value="right_top" <?php selected( 'right_top', $size['crop'], true ) ?>><?php esc_html_e( 'Right Top', 'draftpress-custom-image-sizes' ) ?></option>
+										<option value="left_center" <?php selected( 'left_center', $size['crop'], true ) ?>><?php esc_html_e( 'Left Center', 'draftpress-custom-image-sizes' ) ?></option>
+										<option value="center_center" <?php selected( 'center_center', $size['crop'], true ) ?>><?php esc_html_e( 'Center Center', 'draftpress-custom-image-sizes' ) ?></option>
+										<option value="right_center" <?php selected( 'right_center', $size['crop'], true ) ?>><?php esc_html_e( 'Right Center', 'draftpress-custom-image-sizes' ) ?></option>
+										<option value="left_bottom" <?php selected( 'left_bottom', $size['crop'], true ) ?>><?php esc_html_e( 'Left Bottom', 'draftpress-custom-image-sizes' ) ?></option>
+										<option value="center_bottom" <?php selected( 'center_bottom', $size['crop'], true ) ?>><?php esc_html_e( 'Center Bottom', 'draftpress-custom-image-sizes' ) ?></option>
+										<option value="right_bottom" <?php selected( 'right_bottom', $size['crop'], true ) ?>><?php esc_html_e( 'Right Bottom', 'draftpress-custom-image-sizes' ) ?></option>
 									</select>
 								</td>
 								<td class="<?php echo self::$prefix_dash ?>repeater-item-action">
@@ -89,7 +89,7 @@
 
 				<?php wp_nonce_field( self::$prefix . 'settings' ) ?>
 				<p>
-					<button class="btn btn-info" type="submit" name="submit"><i class="fa fa-hdd-o fa-lg"></i> <?php esc_html_e( 'Save', '99robots-custom-image-sizes' ) ?></button>
+					<button class="btn btn-info" type="submit" name="submit"><i class="fa fa-hdd-o fa-lg"></i> <?php esc_html_e( 'Save', 'draftpress-custom-image-sizes' ) ?></button>
 				</p>
 
 			</form>
@@ -99,14 +99,14 @@
 					<div class="modal-content">
 						<div class="modal-header">
 							<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-							<h4 class="modal-title"><?php esc_html_e( 'Are you sure?', '99robots-custom-image-sizes' ) ?></h4>
+							<h4 class="modal-title"><?php esc_html_e( 'Are you sure?', 'draftpress-custom-image-sizes' ) ?></h4>
 						</div>
 						<div class="modal-body">
-							<p><?php esc_html_e( 'Are you sure you want to delete this image size? If so, all future image uploads will not have this custom image size generated.', '99robots-custom-image-sizes' ) ?></p>
+							<p><?php esc_html_e( 'Are you sure you want to delete this image size? If so, all future image uploads will not have this custom image size generated.', 'draftpress-custom-image-sizes' ) ?></p>
 						</div>
 						<div class="modal-footer">
 							<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-							<button type="button" class="btn btn-danger <?php echo self::$prefix_dash ?>delete-image-size" data-dismiss="modal"><?php esc_html_e( 'Delete', '99robots-custom-image-sizes' ) ?></button>
+							<button type="button" class="btn btn-danger <?php echo self::$prefix_dash ?>delete-image-size" data-dismiss="modal"><?php esc_html_e( 'Delete', 'draftpress-custom-image-sizes' ) ?></button>
 						</div>
 					</div><!-- /.modal-content -->
 				</div><!-- /.modal-dialog -->

--- a/views/sidebar.php
+++ b/views/sidebar.php
@@ -3,7 +3,7 @@
 	<div class="panel panel-default">
 
 		<div class="panel-heading">
-			<h3 class="panel-title"><?php esc_html_e( 'Signup now to get notified of plugin updates, awesome themes, and more. Over 10,000+ already have:', '99robots-custom-image-sizes' ) ?></h3>
+			<h3 class="panel-title"><?php esc_html_e( 'Signup now to get notified of plugin updates, awesome themes, and more. Over 10,000+ already have:', 'draftpress-custom-image-sizes' ) ?></h3>
 		</div>
 
 		<div class="panel-body">
@@ -23,7 +23,7 @@
 			<form action="//wpsite.us5.list-manage.com/subscribe/post?u=82c2341134bbdc37714642adb&amp;id=642b18616e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate style="padding-left: 0;">
 				<div id="mc_embed_signup_scroll">
 					<div style="margin-bottom: 20px;">
-						<input type="email" value="" name="EMAIL" class="required email form-control" id="mce-EMAIL" placeholder="<?php esc_html_e( 'Email Address', '99robots-custom-image-sizes' ) ?>">
+						<input type="email" value="" name="EMAIL" class="required email form-control" id="mce-EMAIL" placeholder="<?php esc_html_e( 'Email Address', 'draftpress-custom-image-sizes' ) ?>">
 					</div>
 					<div id="mce-responses" class="clear">
 						<div class="response" id="mce-error-response" style="display:none"></div>
@@ -42,12 +42,12 @@
 	<div class="panel panel-default">
 
 		<div class="panel-heading">
-			<h3 class="panel-title"><?php esc_html_e( 'Must-Read Articles', '99robots-custom-image-sizes' ) ?></h3>
+			<h3 class="panel-title"><?php esc_html_e( 'Must-Read Articles', 'draftpress-custom-image-sizes' ) ?></h3>
 		</div>
 
 		<div class="panel-body">
 			<div class="wpsite_feed">
-				<script src="http://feeds.feedburner.com/99robots?format=sigpro" type="text/javascript" ></script><noscript><p><?php esc_html_e( 'Subscribe to 99 Robots Feed:', '99robots-custom-image-sizes' ) ?> <a href="http://feeds.feedburner.com/99robots"></a><br/><?php esc_html_e( 'Powered by FeedBurner', '99robots-custom-image-sizes' ) ?></p> </noscript>
+				<script src="http://feeds.feedburner.com/99robots?format=sigpro" type="text/javascript" ></script><noscript><p><?php esc_html_e( 'Subscribe to 99 Robots Feed:', 'draftpress-custom-image-sizes' ) ?> <a href="http://feeds.feedburner.com/99robots"></a><br/><?php esc_html_e( 'Powered by FeedBurner', 'draftpress-custom-image-sizes' ) ?></p> </noscript>
 			</div>
 		</div>
 
@@ -56,7 +56,7 @@
 	<div class="panel panel-default">
 
 		<div class="panel-heading">
-			<h3 class="panel-title"><?php esc_html_e( 'Need a Plugin or Theme Developed?', '99robots-custom-image-sizes' ) ?></h3>
+			<h3 class="panel-title"><?php esc_html_e( 'Need a Plugin or Theme Developed?', 'draftpress-custom-image-sizes' ) ?></h3>
 		</div>
 
 		<div class="panel-body">


### PR DESCRIPTION
### Made compatible with WordPress 5.8
Tested & functional under WordPress Version 5.8

Updated Text Domain:  `99robots-custom-image-sizes`  to `draftpress-custom-image-sizes` 