### PR TITLE
Remove problematic timezone code, add link to GitHub in plugin description, and update some minor plugin metadata as appropriate.

### DIFF
--- a/99robots-custom-image-sizes.php
+++ b/99robots-custom-image-sizes.php
@@ -5,7 +5,7 @@
  * Description:	Custom Image Sizes by DraftPress is a quick and simple way for you to add your own image sizes to your WordPress site.
  * Version: 1.2.9
  * Requires at least: 4.5
- * Tested up to: 6.2
+ * Tested up to: 6.3
  * Requires PHP: 5.6
  * Author: DraftPress
  * Author URI: https://draftpress.com/

--- a/99robots-custom-image-sizes.php
+++ b/99robots-custom-image-sizes.php
@@ -3,7 +3,10 @@
  * Plugin Name:	Custom Image Sizes by DraftPress
  * Plugin URI:	https://wordpress.org/plugins/custom-image-sizes-by-draftpress/
  * Description:	Custom Image Sizes by DraftPress is a quick and simple way for you to add your own image sizes to your WordPress site.
- * Version: 1.2.8
+ * Version: 1.2.9
+ * Requires at least: 4.5
+ * Tested up to: 6.2
+ * Requires PHP: 5.6
  * Author: DraftPress
  * Author URI: https://draftpress.com/
  * License: GPL2
@@ -26,7 +29,7 @@ class NNR_Custom_Image_Sizes {
 	 * NNR_Custom_Image_Sizes version.
 	 * @var string
 	 */
-	public $version = '1.2.8';
+	public $version = '1.2.9';
 
 	/**
 	 * The single instance of the class.

--- a/99robots-custom-image-sizes.php
+++ b/99robots-custom-image-sizes.php
@@ -123,9 +123,6 @@ class NNR_Custom_Image_Sizes {
 	 */
 	private function hooks() {
 
-		// Set default timezone
-		date_default_timezone_set( timezone_name_from_abbr( null, (int) get_option( 'gmt_offset' ) * 3600 , true ) );
-
 		add_action( 'plugins_loaded', array( $this, 'load_plugin_textdomain' ) );
 		add_action( 'init', array( $this, 'init' ) );
 		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_links' ) );

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,9 @@ Contributors: 99robots, charliepatel, DraftPress
 Donate link:
 Tags: image sizes, images, image, size, sizes, custom sizes, custom image, custom images
 Requires at least: 4.5
-Tested up to: 6.0.1
-Stable tag: 1.2.8
+Tested up to: 6.2
+Requires PHP: 5.6
+Stable tag: 1.2.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,7 +15,9 @@ Custom Image Sizes by 99 Robots is a quick and simple way for you to add your ow
 
 Custom Image Sizes by 99 Robots is a quick and simple way for you to add your own image sizes to your WordPress site.
 
-Also please check out our other [plugins](https://draftpress.com/products/?utm_source=wprepo&utm_medium=custom-image-sizes&utm_campaign=desc) :)
+You can view this plugin on GitHub at: [https://github.com/99robots/99robots-custom-image-sizes](https://github.com/99robots/99robots-custom-image-sizes)
+
+Also, please [check out our other plugins](https://draftpress.com/products/?utm_source=wprepo&utm_medium=custom-image-sizes&utm_campaign=desc) :)
 
 == Installation ==
 
@@ -28,6 +31,11 @@ Also please check out our other [plugins](https://draftpress.com/products/?utm_s
 2. Select your image size when inserting image into a post
 
 == Changelog ==
+= 1.2.9 = 2023-21-03
+* Removed code that was potentially causing timezone issues.
+* Added mention of GitHub to plugin description.
+* Added & updated some requirement & testing details for the plugin.
+
 = 1.2.8 = 2022-08-05
 * Compatible with WordPress 6.0.1
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: 99robots, charliepatel, DraftPress
 Donate link:
 Tags: image sizes, images, image, size, sizes, custom sizes, custom image, custom images
 Requires at least: 4.5
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 5.6
 Stable tag: 1.2.9
 License: GPLv2 or later
@@ -31,10 +31,11 @@ Also, please [check out our other plugins](https://draftpress.com/products/?utm_
 2. Select your image size when inserting image into a post
 
 == Changelog ==
-= 1.2.9 = 2023-21-03
+= 1.2.9 = 2023-07-26
 * Removed code that was potentially causing timezone issues.
 * Added mention of GitHub to plugin description.
 * Added & updated some requirement & testing details for the plugin.
+* Compatible with WordPress 6.3.x.
 
 = 1.2.8 = 2022-08-05
 * Compatible with WordPress 6.0.1
@@ -49,7 +50,7 @@ Also, please [check out our other plugins](https://draftpress.com/products/?utm_
 = 1.2.5 = 2020-09-14
 * Updated to make compatible with WordPress 5.5.1
 
-= 1.2.4 = 2020-27-05
+= 1.2.4 = 2020-05-27
 * DraftPress added as a contributor
 
 = 1.2.3 = 2020-05-05


### PR DESCRIPTION
This addresses https://wordpress.org/support/topic/critical-timezone-warning-in-wordpress-6-0-2/ as well as https://wordpress.org/support/topic/suggestion-provide-link-to-github/ while also making sure it's known it will work with WordPress 6.2, has some more fleshed out plugin metadata on what it requires/guarantees what it works with, and did a minor version bump as it's ultimately a bugfix release with some minor metadata refinements.

The one part I'm curious about is why timezones were ever coming into play with this plugin. It seems like it added code that was potentially problematic (causing active problems for those also using The Events Calendar & potentially other plugins/etc.) while then really not doing anything needed by this plugin. I've opted to suggest the removal of that code, but I'd certainly be open to accommodating what it was previously doing, but not in a way WordPress' own Site Health tool says is a critical issue that has verified conflicts with other plugins resulting from it.